### PR TITLE
Add CI workflows for preview and final NuGet packages

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -1,0 +1,80 @@
+name: Build and Publish Preview NuGet Package
+
+on:
+  push:
+    branches:
+      - Development
+  pull_request:
+    branches:
+      - Development
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build the solution (Release)
+      run: dotnet build Berrevoets.MessagesDecoders/Berrevoets.MessagesDecoders.csproj --configuration Release
+
+    - name: Run tests
+      run: dotnet test --no-restore --verbosity normal
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Extract version from .csproj and append -preview
+      id: extract-version
+      shell: bash
+      run: |
+        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.MessagesDecoders/Berrevoets.MessagesDecoders.csproj)
+        if [ -z "$VERSION" ]; then
+          echo "Error: Version could not be extracted."
+          exit 1
+        fi
+        VERSION="$VERSION-preview"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "Version extracted: $VERSION"
+
+    - name: Build the solution (Release) again for packaging
+      run: |
+        echo "Building NuGet package with version: ${{ env.VERSION }}"
+        dotnet build Berrevoets.MessagesDecoders/Berrevoets.MessagesDecoders.csproj --configuration Release /p:PackageVersion=${{ env.VERSION }}
+
+    - name: Pack Preview NuGet package (with symbols)
+      run: |
+        echo "Packing NuGet package with version: ${{ env.VERSION }}"
+        dotnet pack Berrevoets.MessagesDecoders/Berrevoets.MessagesDecoders.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+
+    - name: Publish Preview NuGet package
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Publish Symbol Package (.snupkg)
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,64 @@
+name: Build and Publish Final NuGet Package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build the solution
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test --no-restore --verbosity normal
+
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build the solution
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Pack Final NuGet package (with symbols)
+      run: dotnet pack Berrevoets.MessagesDecoders/Berrevoets.MessagesDecoders.csproj --configuration Release --output "${{ github.workspace }}\output" /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+
+    - name: Publish Final NuGet package
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Publish Symbol Package (.snupkg)
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Berrevoets.MessagesDecoders.sln
+++ b/Berrevoets.MessagesDecoders.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Berrevoets.MessagesDecoders
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8447D00D-E093-422D-9D15-1139EF6D71D0}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\CI-development.yml = .github\workflows\CI-development.yml
+		.github\workflows\CI.yml = .github\workflows\CI.yml
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Added `CI-development.yml` for building and publishing preview NuGet packages on `Development` branch changes. Steps include setting up .NET 8.0.x, restoring dependencies, building, testing, versioning, packing, and publishing to NuGet.org.

Added `CI.yml` for building and publishing final NuGet packages on `main` branch changes. Steps include setting up .NET 8.0.x, restoring dependencies, building, testing, packing, and publishing to NuGet.org.

Updated `Berrevoets.MessagesDecoders.sln` to include new workflow files and updated `VisualStudioVersion` to `17.11.35327.3`.