### PR TITLE
Fix branch name case in CI workflow configuration

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -3,10 +3,10 @@ name: Build and Publish Preview NuGet Package
 on:
   push:
     branches:
-      - Development
+      - development
   pull_request:
     branches:
-      - Development
+      - development
 
 jobs:
   build:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -72,8 +72,8 @@ jobs:
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -72,9 +72,8 @@ jobs:
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
+      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Updated the branch name in `CI-development.yml` from `Development` to `development` in both `push` and `pull_request` sections to ensure the CI pipeline triggers correctly for the newly named branch.